### PR TITLE
Cursor scale system + high-res support + apply result feedback

### DIFF
--- a/Mousecape/Mousecape.xcodeproj/project.pbxproj
+++ b/Mousecape/Mousecape.xcodeproj/project.pbxproj
@@ -76,6 +76,12 @@
 		FAAEF950189EFC9800145DF8 /* apply.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8FF770189D66D800750E51 /* apply.m */; };
 		FAAEF951189F0CC300145DF8 /* restore.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8FF76A189D664400750E51 /* restore.m */; };
 		FAAEF957189F4ED300145DF8 /* scale.m in Sources */ = {isa = PBXBuildFile; fileRef = FAAEF956189F4ED300145DF8 /* scale.m */; };
+		9C68EEBB9D4B4A07BDCB9DF4 /* innerShadow.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C0A58B5D987469C80FCB4DD /* innerShadow.m */; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* innerShadow.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C0A58B5D987469C80FCB4DD /* innerShadow.m */; };
+		B2C3D4E5F6A7B8C9D0E1F2A4 /* innerShadow.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C0A58B5D987469C80FCB4DD /* innerShadow.m */; };
+		D3E4F5A6B7C8D9E0F1A2B3C4 /* outerGlow.m in Sources */ = {isa = PBXBuildFile; fileRef = E4F5A6B7C8D9E0F1A2B3C4D5 /* outerGlow.m */; };
+		C2D3E4F5A6B7C8D9E0F1A2B3 /* outerGlow.m in Sources */ = {isa = PBXBuildFile; fileRef = E4F5A6B7C8D9E0F1A2B3C4D5 /* outerGlow.m */; };
+		A1B2C3D4E5F6789ABCDEF012 /* outerGlow.m in Sources */ = {isa = PBXBuildFile; fileRef = E4F5A6B7C8D9E0F1A2B3C4D5 /* outerGlow.m */; };
 		FAAEF958189F4F8200145DF8 /* scale.m in Sources */ = {isa = PBXBuildFile; fileRef = FAAEF956189F4ED300145DF8 /* scale.m */; };
 		FABA44D421D9D7D0009B10D9 /* NSBitmapImageRep+ColorSpace.m in Sources */ = {isa = PBXBuildFile; fileRef = FABA44D321D9D7D0009B10D9 /* NSBitmapImageRep+ColorSpace.m */; };
 		FABA44D521D9D947009B10D9 /* NSBitmapImageRep+ColorSpace.m in Sources */ = {isa = PBXBuildFile; fileRef = FABA44D321D9D7D0009B10D9 /* NSBitmapImageRep+ColorSpace.m */; };
@@ -88,6 +94,9 @@
 		FAEE652F18A047E8003AA182 /* MCLibraryController.m in Sources */ = {isa = PBXBuildFile; fileRef = FAEE651718A047E8003AA182 /* MCLibraryController.m */; };
 		FAEE653218A047E8003AA182 /* MCCursor.m in Sources */ = {isa = PBXBuildFile; fileRef = FAEE651E18A047E8003AA182 /* MCCursor.m */; };
 		FAEE653318A047E8003AA182 /* MCCursorLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = FAEE652018A047E8003AA182 /* MCCursorLibrary.m */; };
+		DEACCEL002ACCEL0000000001 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEACCEL001ACCEL0000000001 /* Accelerate.framework */; };
+		DEACCEL003ACCEL0000000001 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEACCEL001ACCEL0000000001 /* Accelerate.framework */; };
+		DEACCEL004ACCEL0000000001 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEACCEL001ACCEL0000000001 /* Accelerate.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -186,9 +195,12 @@
 		FA8FF76D189D66CB00750E51 /* backup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = backup.m; sourceTree = "<group>"; };
 		FA8FF76F189D66D100750E51 /* apply.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = apply.h; sourceTree = "<group>"; };
 		FA8FF770189D66D800750E51 /* apply.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = apply.m; sourceTree = "<group>"; };
+		1C0A58B5D987469C80FCB4DD /* innerShadow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = innerShadow.m; sourceTree = "<group>"; };
+		E4F5A6B7C8D9E0F1A2B3C4D5 /* outerGlow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = outerGlow.m; sourceTree = "<group>"; };
 		FA8FF772189D67AA00750E51 /* create.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = create.h; sourceTree = "<group>"; };
 		FA8FF773189D67B100750E51 /* create.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = create.m; sourceTree = "<group>"; };
 		FAAEF8F6189EB34700145DF8 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		DEACCEL001ACCEL0000000001 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		FAAEF955189F4ECC00145DF8 /* scale.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = scale.h; sourceTree = "<group>"; };
 		FAAEF956189F4ED300145DF8 /* scale.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = scale.m; sourceTree = "<group>"; };
 		FABA44D221D9D7D0009B10D9 /* NSBitmapImageRep+ColorSpace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSBitmapImageRep+ColorSpace.h"; sourceTree = "<group>"; };
@@ -261,6 +273,7 @@
 				DE2E175A2F5B2CA000055E78 /* SystemConfiguration.framework in Frameworks */,
 				DE2E175B2F5B2CA900055E78 /* ApplicationServices.framework in Frameworks */,
 				DE2E17592F5B2C9000055E78 /* Cocoa.framework in Frameworks */,
+				DEACCEL002ACCEL0000000001 /* Accelerate.framework in Frameworks */,
 			);
 		};
 		FAC69F5E189D603C00BC829D /* Frameworks */ = {
@@ -272,6 +285,7 @@
 				FA359849189DC40100288163 /* Security.framework in Frameworks */,
 				DE4A92B62F4F8C0100288163 /* SystemConfiguration.framework in Frameworks */,
 				FAC69F65189D603C00BC829D /* Cocoa.framework in Frameworks */,
+				DEACCEL003ACCEL0000000001 /* Accelerate.framework in Frameworks */,
 			);
 		};
 		FAC69FAA189D608900BC829D /* Frameworks */ = {
@@ -281,6 +295,7 @@
 				FA359853189E040D00288163 /* SystemConfiguration.framework in Frameworks */,
 				FAC69FDA189D632B00BC829D /* Cocoa.framework in Frameworks */,
 				1B57EC46401E4928B48C5E89 /* ArgumentParser in Frameworks */,
+				DEACCEL004ACCEL0000000001 /* Accelerate.framework in Frameworks */,
 			);
 		};
 /* End PBXFrameworksBuildPhase section */
@@ -452,6 +467,8 @@
 				FABA44D321D9D7D0009B10D9 /* NSBitmapImageRep+ColorSpace.m */,
 				7A5B757C0780EA0A10BF1469 /* main.swift */,
 				CF122E4B298E5744EE9F0578 /* mousecloak-Bridging-Header.h */,
+			1C0A58B5D987469C80FCB4DD /* innerShadow.m */,
+			E4F5A6B7C8D9E0F1A2B3C4D5 /* outerGlow.m */,
 			);
 			path = mousecloak;
 			sourceTree = "<group>";
@@ -648,6 +665,8 @@
 				DE2E17612F5B2D6300055E78 /* scale.m in Sources */,
 				DE2E17542F5B2BE200055E78 /* MCLogger.m in Sources */,
 				DE2E174E2F5B2BB000055E78 /* listen.m in Sources */,
+				A1B2C3D4E5F6A7B8C9D0E1F2 /* innerShadow.m in Sources */,
+				C2D3E4F5A6B7C8D9E0F1A2B3 /* outerGlow.m in Sources */,
 			);
 		};
 		FAC69F5D189D603C00BC829D /* Sources */ = {
@@ -687,6 +706,8 @@
 				DE3662082EFAAAB600D94521 /* CapePreviewPanel.swift in Sources */,
 				DE3662092EFAAAB600D94521 /* Cursor.swift in Sources */,
 				DE36620A2EFAAAB600D94521 /* AppEnums.swift in Sources */,
+				B2C3D4E5F6A7B8C9D0E1F2A4 /* innerShadow.m in Sources */,
+				A1B2C3D4E5F6789ABCDEF012 /* outerGlow.m in Sources */,
 				FAC69FDC189D636700BC829D /* MCDefs.m in Sources */,
 				DEBC96042F165800004E6C07 /* MCLogger.m in Sources */,
 				FA359840189DA3C100288163 /* MCPrefs.m in Sources */,
@@ -707,6 +728,8 @@
 				FA8FF774189D67B100750E51 /* create.m in Sources */,
 				FABA44D421D9D7D0009B10D9 /* NSBitmapImageRep+ColorSpace.m in Sources */,
 				9CB312EE7052700D9F29C682 /* main.swift in Sources */,
+				9C68EEBB9D4B4A07BDCB9DF4 /* innerShadow.m in Sources */,
+				D3E4F5A6B7C8D9E0F1A2B3C4 /* outerGlow.m in Sources */,
 			);
 		};
 /* End PBXSourcesBuildPhase section */

--- a/Mousecape/Mousecape/SwiftUI/Models/AppEnums.swift
+++ b/Mousecape/Mousecape/SwiftUI/Models/AppEnums.swift
@@ -77,7 +77,10 @@ enum CursorScale: Int, CaseIterable, Identifiable {
     case scale100 = 100
     case scale200 = 200
     case scale500 = 500
+    case scale800 = 800
     case scale1000 = 1000
+    case scale1600 = 1600
+    case scale6400 = 6400
 
     var id: Int { rawValue }
 
@@ -86,7 +89,10 @@ enum CursorScale: Int, CaseIterable, Identifiable {
         case .scale100: return "1x"
         case .scale200: return "2x"
         case .scale500: return "5x"
+        case .scale800: return "8x"
         case .scale1000: return "10x"
+        case .scale1600: return "16x"
+        case .scale6400: return "64x"
         }
     }
 

--- a/Mousecape/Mousecape/SwiftUI/Models/AppEnums.swift
+++ b/Mousecape/Mousecape/SwiftUI/Models/AppEnums.swift
@@ -353,3 +353,18 @@ enum WindowsCursorGroup: Int, CaseIterable, Identifiable {
         return nil
     }
 }
+
+// MARK: - Scale Mode
+
+/// Cursor scale mode: global (one scale for all) or custom (per-cursor-type)
+enum ScaleMode: String, CaseIterable, Identifiable {
+    case global
+    case custom
+    var id: String { rawValue }
+    var displayName: String {
+        switch self {
+        case .global: return String(localized: "Global")
+        case .custom: return String(localized: "Custom")
+        }
+    }
+}

--- a/Mousecape/Mousecape/SwiftUI/Models/AppState.swift
+++ b/Mousecape/Mousecape/SwiftUI/Models/AppState.swift
@@ -241,16 +241,7 @@ final class AppState: @unchecked Sendable {
     /// Load cursor scale from preferences and apply it
     private func applySavedCursorScale() {
         let preferenceDomain = "com.sdmj76.Mousecape"
-        let scaleModeKey = "MCScaleMode"
         let cursorScaleKey = "MCCursorScale"
-
-        // Sync C global variable from persisted preferences BEFORE reading it
-        if let modeStr = CFPreferencesCopyAppValue(scaleModeKey as CFString, preferenceDomain as CFString) as? String,
-           modeStr == "custom" {
-            setCustomScaleMode(true)
-        } else {
-            setCustomScaleMode(false)
-        }
 
         if customScaleMode() {
             // Custom mode: applyCape() handles per-cursor scaling internally
@@ -451,15 +442,53 @@ final class AppState: @unchecked Sendable {
         debugLog("Cape: \(cape.name) (\(cape.identifier))")
         debugLog("Cursors count: \(cape.cursors.count)")
 
-        libraryController?.applyCape(cape.underlyingLibrary)
-        appliedCape = cape
+        // Use the new method that returns detailed results
+        guard let result = libraryController?.applyCape(withResult: cape.underlyingLibrary) as? [String: Any] else {
+            debugLog("Apply failed - nil result")
+            operationResultMessage = String(localized: "Failed to apply cape.")
+            operationResultIsSuccess = false
+            showOperationResult = true
+            return
+        }
+
+        let success = result["success"] as? Bool ?? false
+        let successCount = result["successCount"] as? UInt ?? 0
+        let failedCount = result["failedCount"] as? UInt ?? 0
+        let skippedCount = result["skippedCount"] as? UInt ?? 0
+        let failedIdentifiers = result["failedIdentifiers"] as? [String] ?? []
+        let skippedIdentifiers = result["skippedIdentifiers"] as? [String] ?? []
+
+        if success {
+            appliedCape = cape
+
+            // Build detailed message
+            var message = "\"\(cape.name)\" "
+            if failedCount == 0 && skippedCount == 0 {
+                message += String(localized: "applied successfully.")
+            } else {
+                message += String(format: String(localized: "applied with warnings (%u succeeded, %u failed, %u skipped)"),
+                                successCount, failedCount, skippedCount)
+            }
+
+            if failedCount > 0 {
+                message += "\n\n" + String(localized: "Failed cursors:") + "\n" + failedIdentifiers.joined(separator: "\n")
+                debugLog("Apply completed with failures: \(failedIdentifiers)")
+            }
+
+            operationResultMessage = message
+            operationResultIsSuccess = (failedCount == 0)
+        } else {
+            operationResultMessage = String(localized: "Failed to apply cape - no cursors were successfully applied.")
+            operationResultIsSuccess = false
+            debugLog("Apply failed - no cursors succeeded")
+        }
+        showOperationResult = true
 
         debugLog("Apply completed, saving preferences...")
 
         // Save identifier for "Apply Last Cape on Launch" feature
         UserDefaults.standard.set(cape.identifier, forKey: "lastAppliedCapeIdentifier")
         // Also write MCAppliedCursor for session monitor (ObjC listen.m)
-        // Uses CFPreferences to write to current user + current host domain
         CFPreferencesSetValue(
             "MCAppliedCursor" as CFString,
             cape.identifier as CFString,

--- a/Mousecape/Mousecape/SwiftUI/Models/AppState.swift
+++ b/Mousecape/Mousecape/SwiftUI/Models/AppState.swift
@@ -241,22 +241,40 @@ final class AppState: @unchecked Sendable {
     /// Load cursor scale from preferences and apply it
     private func applySavedCursorScale() {
         let preferenceDomain = "com.sdmj76.Mousecape"
+        let scaleModeKey = "MCScaleMode"
         let cursorScaleKey = "MCCursorScale"
 
-        // Read saved scale value
-        if let value = CFPreferencesCopyAppValue(cursorScaleKey as CFString, preferenceDomain as CFString) as? Double {
-            debugLog("Loading saved cursor scale: \(value)")
-            // Apply the scale using ObjC function
-            let success = setCursorScale(Float(value))
-            if success {
-                debugLog("Successfully applied cursor scale on startup")
-            } else {
-                debugLog("Failed to apply cursor scale on startup")
+        // Sync C global variable from persisted preferences BEFORE reading it
+        if let modeStr = CFPreferencesCopyAppValue(scaleModeKey as CFString, preferenceDomain as CFString) as? String,
+           modeStr == "custom" {
+            setCustomScaleMode(true)
+        } else {
+            setCustomScaleMode(false)
+        }
+
+        if customScaleMode() {
+            // Custom mode: applyCape() handles per-cursor scaling internally
+            // Just ensure CGSSetCursorScale matches maxScale
+            debugLog("Custom scale mode on startup")
+            if let maxScale = CFPreferencesCopyAppValue(cursorScaleKey as CFString, preferenceDomain as CFString) as? Double {
+                debugLog("Setting max cursor scale: \(maxScale)")
+                _ = setCursorScale(Float(maxScale))
             }
         } else {
-            debugLog("No saved cursor scale found, using default (1.0)")
-            // Apply default scale
-            _ = setCursorScale(1.0)
+            // Global mode: existing behavior
+            debugLog("Global scale mode on startup")
+            if let value = CFPreferencesCopyAppValue(cursorScaleKey as CFString, preferenceDomain as CFString) as? Double {
+                debugLog("Loading saved cursor scale: \(value)")
+                let success = setCursorScale(Float(value))
+                if success {
+                    debugLog("Successfully applied cursor scale on startup")
+                } else {
+                    debugLog("Failed to apply cursor scale on startup")
+                }
+            } else {
+                debugLog("No saved cursor scale found, using default (1.0)")
+                _ = setCursorScale(1.0)
+            }
         }
     }
 
@@ -401,6 +419,17 @@ final class AppState: @unchecked Sendable {
         } else {
             // Import succeeded, reload the cape list
             loadCapes()
+
+            // Find the newly imported cape (may have been auto-renamed)
+            // Match by original name first, then fall back to name prefix
+            let importedCape = capes.first { $0.name == capeName }
+                ?? capes.first { $0.name.hasPrefix(capeName) }
+
+            // Auto-apply the newly imported cape
+            if let importedCape = importedCape {
+                applyCape(importedCape)
+                selectedCape = importedCape
+            }
 
             // Show success message with cape name
             operationResultMessage = "\"\(capeName)\" \(String(localized:"has been imported."))"

--- a/Mousecape/Mousecape/SwiftUI/Models/AppState.swift
+++ b/Mousecape/Mousecape/SwiftUI/Models/AppState.swift
@@ -261,10 +261,11 @@ final class AppState: @unchecked Sendable {
                 _ = setCursorScale(Float(maxScale))
             }
         } else {
-            // Global mode: existing behavior
+            // Global mode: use separate global scale preference
             debugLog("Global scale mode on startup")
-            if let value = CFPreferencesCopyAppValue(cursorScaleKey as CFString, preferenceDomain as CFString) as? Double {
-                debugLog("Loading saved cursor scale: \(value)")
+            let globalScaleKey = "MCGlobalCursorScale"
+            if let value = CFPreferencesCopyAppValue(globalScaleKey as CFString, preferenceDomain as CFString) as? Double {
+                debugLog("Loading saved global cursor scale: \(value)")
                 let success = setCursorScale(Float(value))
                 if success {
                     debugLog("Successfully applied cursor scale on startup")

--- a/Mousecape/Mousecape/SwiftUI/Models/Cursor.swift
+++ b/Mousecape/Mousecape/SwiftUI/Models/Cursor.swift
@@ -13,7 +13,7 @@ import ImageIO
 /// Swift wrapper around MCCursor for SwiftUI usage
 @Observable
 final class Cursor: Identifiable, Hashable {
-    let id: UUID
+    let id: ObjectIdentifier
     private let objcCursor: MCCursor
 
     /// Cached image to avoid repeated NSImage allocation from imageWithAllReps
@@ -148,7 +148,7 @@ final class Cursor: Identifiable, Hashable {
     // MARK: - Initialization
 
     init(objcCursor: MCCursor) {
-        self.id = UUID()
+        self.id = ObjectIdentifier(objcCursor)
         self.objcCursor = objcCursor
     }
 

--- a/Mousecape/Mousecape/SwiftUI/Models/CursorLibrary.swift
+++ b/Mousecape/Mousecape/SwiftUI/Models/CursorLibrary.swift
@@ -381,7 +381,7 @@ extension CursorLibrary {
     func validate() throws {
         let maxFrameCount = 24  // MCMaxFrameCount
         let maxHotspotValue: CGFloat = 31.99  // MCMaxHotspotValue
-        let maxImportSize = 512  // MCMaxImportSize
+        let maxImportSize = 2048  // MCMaxImportSize
 
         var errors: [ValidationError] = []
 

--- a/Mousecape/Mousecape/SwiftUI/MousecapeApp.swift
+++ b/Mousecape/Mousecape/SwiftUI/MousecapeApp.swift
@@ -303,6 +303,7 @@ class WindowDelegate: NSObject, NSWindowDelegate {
 /// Hides NSToolbarPlatterView (toolbar background) in macOS 15+
 enum ToolbarHider {
     @MainActor private static var timer: Timer?
+    @MainActor private static var checkCount: Int = 0
 
     @MainActor
     static func startMonitoring() {
@@ -310,9 +311,9 @@ enum ToolbarHider {
         hideToolbarPlatter()
 
         // Monitor for view changes - check frequently at first, then less often
-        var checkCount = 0
+        checkCount = 0
         timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 hideToolbarPlatter()
                 checkCount += 1
 
@@ -320,7 +321,7 @@ enum ToolbarHider {
                 if checkCount >= 20 {
                     timer?.invalidate()
                     timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
-                        DispatchQueue.main.async {
+                        Task { @MainActor in
                             hideToolbarPlatter()
                         }
                     }

--- a/Mousecape/Mousecape/SwiftUI/Utilities/CursorImageScaler.swift
+++ b/Mousecape/Mousecape/SwiftUI/Utilities/CursorImageScaler.swift
@@ -13,18 +13,18 @@ enum CursorImageScaler {
 
     // MARK: - Constants
 
-    /// Standard cursor size in pixels for 2x HiDPI (64x64 pixels = 32x32 points)
-    static let standardCursorSize: Int = 64
+    /// Standard cursor size in pixels for high-resolution rendering (2048x2048 pixels)
+    static let standardCursorSize: Int = 2048
 
     /// Maximum animation frame count (macOS system limit)
     static let maxFrameCount: Int = 24
 
     /// Maximum individual frame size for import validation (pixels)
-    static let maxImportSize: Int = 512
+    static let maxImportSize: Int = 2048
 
     // MARK: - Static Image Scaling
 
-    /// Scale image to standard 64x64 size with aspect fit and transparent padding
+    /// Scale image to standard 2048x2048 size with aspect fit and transparent padding
     static func scaleImageToStandardSize(_ original: NSBitmapImageRep) -> NSBitmapImageRep? {
         let targetSize = standardCursorSize
 
@@ -209,7 +209,7 @@ enum CursorImageScaler {
     ) -> (x: CGFloat, y: CGFloat) {
         let originalWidthF = CGFloat(originalWidth)
         let originalHeightF = CGFloat(originalHeight)
-        let targetSizeF = CGFloat(standardCursorSize)  // 64 pixels
+        let targetSizeF = CGFloat(standardCursorSize)  // 2048 pixels
         let scale = min(targetSizeF / originalWidthF, targetSizeF / originalHeightF)
         let scaledWidth = originalWidthF * scale
         let scaledHeight = originalHeightF * scale
@@ -220,11 +220,11 @@ enum CursorImageScaler {
         let hotspotPixelsX = CGFloat(hotspotX) * scale + offsetX
         let hotspotPixelsY = CGFloat(hotspotY) * scale + offsetY
 
-        // Convert to points (divide by 2 for 2x scale)
+        // Convert to points (divide by 64 for 64x scale)
         // Also clamp to valid range [0, 32)
         let pointsSize: CGFloat = 32.0
-        let hotspotPointsX = min(max(hotspotPixelsX / 2.0, 0), pointsSize - 0.1)
-        let hotspotPointsY = min(max(hotspotPixelsY / 2.0, 0), pointsSize - 0.1)
+        let hotspotPointsX = min(max(hotspotPixelsX / 64.0, 0), pointsSize - 0.1)
+        let hotspotPointsY = min(max(hotspotPixelsY / 64.0, 0), pointsSize - 0.1)
 
         return (hotspotPointsX, hotspotPointsY)
     }

--- a/Mousecape/Mousecape/SwiftUI/Utilities/UserPreferences.swift
+++ b/Mousecape/Mousecape/SwiftUI/Utilities/UserPreferences.swift
@@ -23,6 +23,10 @@ final class UserPreferences: @unchecked Sendable {
         static let appliedCursor = "MCAppliedCursor"
         static let cursorScale = "MCCursorScale"
         static let handedness = "MCHandedness"
+        static let innerShadow = "MCInnerShadow"
+        static let outerGlow = "MCOuterGlow"
+        static let scaleMode = "MCScaleMode"
+        static let perCursorScales = "MCPerCursorScales"
     }
 
     private init() {}

--- a/Mousecape/Mousecape/SwiftUI/Utilities/WindowsCursorConverter.swift
+++ b/Mousecape/Mousecape/SwiftUI/Utilities/WindowsCursorConverter.swift
@@ -37,7 +37,7 @@ enum WindowsCursorError: LocalizedError {
         case .imageDecodeFailed:
             return "Failed to decode image data"
         case .imageTooLarge(let width, let height):
-            return "Image too large (\(width)x\(height)). Maximum supported size is 512x512 pixels."
+            return "Image too large (\(width)x\(height)). Maximum supported size is 2048x2048 pixels."
         }
     }
 }

--- a/Mousecape/Mousecape/SwiftUI/Utilities/WindowsCursorParser.swift
+++ b/Mousecape/Mousecape/SwiftUI/Utilities/WindowsCursorParser.swift
@@ -622,7 +622,7 @@ struct WindowsCursorParser {
         let actualWidth = bmpWidth > 0 ? bmpWidth : width
 
         // Validate dimensions to prevent OOM from malicious files
-        let maxDimension = CursorImageScaler.maxImportSize  // 512
+        let maxDimension = CursorImageScaler.maxImportSize  // 2048
         guard actualWidth > 0 && actualWidth <= maxDimension &&
               actualHeight > 0 && actualHeight <= maxDimension else {
             throw WindowsCursorParserError.invalidFormat("BMP dimensions \(actualWidth)×\(actualHeight) exceed maximum \(maxDimension)×\(maxDimension)")

--- a/Mousecape/Mousecape/SwiftUI/Views/EditOverlayView.swift
+++ b/Mousecape/Mousecape/SwiftUI/Views/EditOverlayView.swift
@@ -909,8 +909,8 @@ private func _processWindowsCursor(convertResult: WindowsCursorResult) async -> 
 
     let hotspotXPixels = CGFloat(convertResult.hotspotX) * scale + offsetX
     let hotspotYPixels = CGFloat(convertResult.hotspotY) * scale + offsetY
-    let hotspotX = min(max(0, hotspotXPixels / 2.0), CGFloat(MCMaxHotspotValue))
-    let hotspotY = min(max(0, hotspotYPixels / 2.0), CGFloat(MCMaxHotspotValue))
+    let hotspotX = min(max(0, hotspotXPixels / 64.0), CGFloat(MCMaxHotspotValue))
+    let hotspotY = min(max(0, hotspotYPixels / 64.0), CGFloat(MCMaxHotspotValue))
 
     let scaledBitmap: NSBitmapImageRep?
     if convertResult.frameCount > 1 {

--- a/Mousecape/Mousecape/SwiftUI/Views/HomeView.swift
+++ b/Mousecape/Mousecape/SwiftUI/Views/HomeView.swift
@@ -262,6 +262,15 @@ struct HomeView: View {
         } message: {
             Text(appState.imageImportWarningMessage)
         }
+        // Apply result alert
+        .alert(
+            appState.operationResultIsSuccess ? "Success" : "Apply Error",
+            isPresented: $appState.showOperationResult
+        ) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(appState.operationResultIsSuccess ? "All cursors applied." : "Some cursors failed to apply.")
+        }
         // Add cursor sheet
         .sheet(isPresented: $appState.showAddCursorSheet) {
             if let cape = appState.editingCape {

--- a/Mousecape/Mousecape/SwiftUI/Views/SettingsView.swift
+++ b/Mousecape/Mousecape/SwiftUI/Views/SettingsView.swift
@@ -62,6 +62,7 @@ struct GeneralSettingsView: View {
     @AppStorage("launchAtLogin") private var launchAtLogin = false
     @AppStorage("doubleClickAction") private var doubleClickAction = 0
     @State private var cursorScale: Double = 1.0
+    @State private var scaleMode: ScaleMode = .global
     @State private var isLeftHanded: Bool = false
     @State private var loginToggleError: String?
     @State private var showLoginError = false
@@ -69,6 +70,8 @@ struct GeneralSettingsView: View {
 
     /// The key used by ObjC code for cursor scale
     private static let cursorScaleKey = "MCCursorScale"
+    private static let scaleModeKey = "MCScaleMode"
+    private static let perCursorScalesKey = "MCPerCursorScales"
     private static let handednessKey = "MCHandedness"
     private static let preferenceDomain = "com.sdmj76.Mousecape"
 
@@ -105,22 +108,49 @@ struct GeneralSettingsView: View {
             }
 
             Section("Cursor Scale") {
-                VStack(alignment: .leading) {
-                    Text("\(String(localized:"Global Scale:")) \(cursorScale, specifier: "%.1f")x")
-                    Slider(value: $cursorScale, in: 0.5...16.0, step: 0.1) {
-                    } minimumValueLabel: {
-                        Text("0.5x")
-                    } maximumValueLabel: {
-                        Text("16.0x")
+                Picker("Scale Mode", selection: $scaleMode) {
+                    ForEach(ScaleMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode)
                     }
-                    .onChange(of: cursorScale) { _, newValue in
-                        saveCursorScale(newValue)
-                        _ = setCursorScale(Float(newValue))
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: scaleMode) { _, newValue in
+                    saveScaleMode(newValue)
+                    if newValue == .global {
+                        // Restore global scale
+                        _ = setCursorScale(Float(cursorScale))
+                        saveCursorScale(cursorScale)
+                        if let cape = appState.appliedCape {
+                            appState.applyCape(cape)
+                        }
+                    } else {
+                        // Apply custom scales
+                        applyCustomScales()
                     }
+                }
 
-                    Text("Scale changes are applied immediately.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                if scaleMode == .global {
+                    VStack(alignment: .leading) {
+                        Text("\(String(localized:"Global Scale:")) \(cursorScale, specifier: "%.1f")x")
+                        Slider(value: $cursorScale, in: 0.5...16.0, step: 0.1) {
+                        } minimumValueLabel: {
+                            Text("0.5x")
+                        } maximumValueLabel: {
+                            Text("16.0x")
+                        }
+                        .onChange(of: cursorScale) { _, newValue in
+                            saveCursorScale(newValue)
+                            _ = setCursorScale(Float(newValue))
+                        }
+
+                        Text("Scale changes are applied immediately.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    NavigationLink("Configure Per-Cursor Scales...") {
+                        CustomScaleView()
+                    }
                 }
             }
 
@@ -151,6 +181,7 @@ struct GeneralSettingsView: View {
         .onAppear {
             loadCursorScale()
             loadHandedness()
+            loadScaleMode()
         }
         .alert("Login Item Error", isPresented: $showLoginError) {
             Button("OK") { }
@@ -199,6 +230,36 @@ struct GeneralSettingsView: View {
         // Also write to UserDefaults so @AppStorage("MCHandedness") in preview views updates reactively
         UserDefaults.standard.set(intValue, forKey: Self.handednessKey)
     }
+
+    /// Load scale mode from CFPreferences and sync C global variable
+    private func loadScaleMode() {
+        if let value = CFPreferencesCopyAppValue(Self.scaleModeKey as CFString, Self.preferenceDomain as CFString) as? String,
+           let mode = ScaleMode(rawValue: value) {
+            scaleMode = mode
+        } else {
+            scaleMode = .global
+        }
+        // CRITICAL: Sync the C global variable so apply.m reads the correct mode
+        setCustomScaleMode(scaleMode == .custom)
+    }
+
+    /// Save scale mode to CFPreferences
+    private func saveScaleMode(_ mode: ScaleMode) {
+        CFPreferencesSetAppValue(
+            Self.scaleModeKey as CFString,
+            mode.rawValue as CFString,
+            Self.preferenceDomain as CFString
+        )
+        CFPreferencesAppSynchronize(Self.preferenceDomain as CFString)
+        // Set direct C variable for reliable in-process communication with ObjC
+        setCustomScaleMode(mode == .custom)
+    }
+
+    /// Apply custom per-cursor scales
+    private func applyCustomScales() {
+        guard let cape = appState.appliedCape else { return }
+        appState.applyCape(cape)
+    }
 }
 
 // MARK: - Appearance Settings
@@ -208,6 +269,13 @@ struct AppearanceSettingsView: View {
     @AppStorage("showAuthorInfo") private var showAuthorInfo = true
     @AppStorage("previewGridColumns") private var previewGridColumns = 0
     @AppStorage("previewDisplayMode") private var previewDisplayMode = 0
+    @State private var innerShadowEnabled: Bool = false
+    @State private var outerGlowEnabled: Bool = false
+    @Environment(AppState.self) private var appState
+
+    private static let innerShadowKey = "MCInnerShadow"
+    private static let outerGlowKey = "MCOuterGlow"
+    private static let preferenceDomain = "com.sdmj76.Mousecape"
 
     var body: some View {
         Form {
@@ -229,10 +297,56 @@ struct AppearanceSettingsView: View {
                     Text("8 \(String(localized:"columns"))").tag(8)
                 }
             }
+
+            Section("Effects") {
+                Toggle("Inner Shadow", isOn: $innerShadowEnabled)
+                    .onChange(of: innerShadowEnabled) { _, newValue in
+                        saveInnerShadow(newValue)
+                        if let cape = appState.appliedCape {
+                            appState.applyCape(cape)
+                        }
+                    }
+
+                Text("Adds an inner shadow effect to cursor edges for better visibility.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Toggle("Outer Glow", isOn: $outerGlowEnabled)
+                    .onChange(of: outerGlowEnabled) { _, newValue in
+                        saveOuterGlow(newValue)
+                        if let cape = appState.appliedCape {
+                            appState.applyCape(cape)
+                        }
+                    }
+
+                Text("Adds a soft glow around the cursor for better visibility on any background.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .formStyle(.grouped)
         .scrollContentBackground(.hidden)
         .navigationTitle("Appearance")
+        .onAppear {
+            if let value = CFPreferencesCopyAppValue(Self.innerShadowKey as CFString, Self.preferenceDomain as CFString) {
+                innerShadowEnabled = (value as? NSNumber)?.boolValue ?? false
+            }
+            if let value = CFPreferencesCopyAppValue(Self.outerGlowKey as CFString, Self.preferenceDomain as CFString) {
+                outerGlowEnabled = (value as? NSNumber)?.boolValue ?? false
+            }
+        }
+    }
+
+    private func saveInnerShadow(_ enabled: Bool) {
+        let intValue = enabled ? 1 : 0
+        CFPreferencesSetAppValue(Self.innerShadowKey as CFString, intValue as CFNumber, Self.preferenceDomain as CFString)
+        CFPreferencesAppSynchronize(Self.preferenceDomain as CFString)
+    }
+
+    private func saveOuterGlow(_ enabled: Bool) {
+        let intValue = enabled ? 1 : 0
+        CFPreferencesSetAppValue(Self.outerGlowKey as CFString, intValue as CFNumber, Self.preferenceDomain as CFString)
+        CFPreferencesAppSynchronize(Self.preferenceDomain as CFString)
     }
 }
 
@@ -453,4 +567,182 @@ struct AdvancedSettingsView: View {
     SettingsView()
         .environment(AppState.shared)
         .frame(width: 600, height: 500)
+}
+
+// MARK: - Custom Scale View
+
+struct CustomScaleView: View {
+    @Environment(AppState.self) private var appState
+    @State private var perCursorScales: [String: Double] = [:]
+    @State private var selectedCursorType: CursorType? = nil
+    @State private var showSetAllAlert = false
+    @State private var setAllValue: Double = 1.0
+    @State private var applyTask: Task<Void, Never>? = nil
+
+    private static let perCursorScalesKey = "MCPerCursorScales"
+    private static let cursorScaleKey = "MCCursorScale"
+    private static let preferenceDomain = "com.sdmj76.Mousecape"
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // Left column: cursor type list
+            List(CursorType.allCases, selection: $selectedCursorType) { cursorType in
+                HStack {
+                    Text(cursorType.displayName)
+                    Spacer()
+                    if let scale = perCursorScales[cursorType.rawValue], scale != 1.0 {
+                        Text("\(scale, specifier: "%.1f")x")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+                .tag(cursorType)
+            }
+            .listStyle(.sidebar)
+            .frame(minWidth: 220, idealWidth: 260)
+
+            Divider()
+
+            // Right column: scale control
+            if let selected = selectedCursorType {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(selected.displayName)
+                        .font(.title2)
+                        .fontWeight(.semibold)
+
+                    Text(selected.rawValue)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+
+                    let currentScale = perCursorScales[selected.rawValue] ?? 1.0
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Scale: \(currentScale, specifier: "%.1f")x")
+                            .font(.headline)
+                        Slider(value: Binding(
+                            get: { currentScale },
+                            set: { newValue in
+                                updateScale(for: selected, to: newValue)
+                            }
+                        ), in: 0.5...16.0, step: 0.1) {
+                        } minimumValueLabel: {
+                            Text("0.5x")
+                        } maximumValueLabel: {
+                            Text("16.0x")
+                        }
+                    }
+
+                    HStack(spacing: 12) {
+                        Button("Reset to 1.0x") {
+                            updateScale(for: selected, to: 1.0)
+                        }
+                        .buttonStyle(.bordered)
+
+                        Button("Set All to This") {
+                            setAllValue = currentScale
+                            showSetAllAlert = true
+                        }
+                        .buttonStyle(.bordered)
+                    }
+
+                    Spacer()
+
+                    HStack {
+                        Button("Reset All to 1.0x") {
+                            resetAllScales()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.red)
+                    }
+                }
+                .padding(20)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                VStack {
+                    Text("Select a cursor type")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                    Text("Choose a cursor from the list to configure its scale.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .navigationTitle("Custom Scales")
+        .onAppear {
+            loadPerCursorScales()
+        }
+        .onDisappear {
+            applyTask?.cancel()
+        }
+        .alert("Set All Scales", isPresented: $showSetAllAlert) {
+            Button("Cancel", role: .cancel) { }
+            Button("Set All") {
+                setAllScales(to: setAllValue)
+            }
+        } message: {
+            Text("Set all cursor scales to \(setAllValue, specifier: "%.1f")x?")
+        }
+    }
+
+    private func loadPerCursorScales() {
+        if let dict = CFPreferencesCopyAppValue(Self.perCursorScalesKey as CFString, Self.preferenceDomain as CFString) as? [String: Double] {
+            perCursorScales = dict
+        } else {
+            perCursorScales = [:]
+        }
+    }
+
+    private func savePerCursorScales() {
+        CFPreferencesSetAppValue(
+            Self.perCursorScalesKey as CFString,
+            perCursorScales as CFPropertyList,
+            Self.preferenceDomain as CFString
+        )
+        CFPreferencesAppSynchronize(Self.preferenceDomain as CFString)
+    }
+
+    private func updateScale(for cursorType: CursorType, to value: Double) {
+        perCursorScales[cursorType.rawValue] = value
+        savePerCursorScales()
+        recalculateMaxScaleAndApply()
+    }
+
+    private func resetAllScales() {
+        perCursorScales = [:]
+        savePerCursorScales()
+        recalculateMaxScaleAndApply()
+    }
+
+    private func setAllScales(to value: Double) {
+        for cursorType in CursorType.allCases {
+            perCursorScales[cursorType.rawValue] = value
+        }
+        savePerCursorScales()
+        recalculateMaxScaleAndApply()
+    }
+
+    private func recalculateMaxScaleAndApply() {
+        let maxScale = perCursorScales.values.max() ?? 1.0
+        // Save maxScale as MCCursorScale
+        CFPreferencesSetAppValue(
+            Self.cursorScaleKey as CFString,
+            maxScale as CFNumber,
+            Self.preferenceDomain as CFString
+        )
+        CFPreferencesAppSynchronize(Self.preferenceDomain as CFString)
+        // Set system scale immediately for visual feedback
+        _ = setCursorScale(Float(maxScale))
+        // Debounce the full cape re-apply (expensive — re-registers all cursors)
+        applyTask?.cancel()
+        applyTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled else { return }
+            if let cape = appState.appliedCape {
+                appState.applyCape(cape)
+            }
+        }
+    }
 }

--- a/Mousecape/Mousecape/SwiftUI/Views/SettingsView.swift
+++ b/Mousecape/Mousecape/SwiftUI/Views/SettingsView.swift
@@ -143,15 +143,8 @@ struct GeneralSettingsView: View {
                         .onChange(of: cursorScale) { _, newValue in
                             saveCursorScale(newValue)
                             _ = setCursorScale(Float(newValue))
-                            // Re-apply cape with new scale (debounced)
-                            applyTask?.cancel()
-                            applyTask = Task { @MainActor in
-                                try? await Task.sleep(for: .milliseconds(500))
-                                guard !Task.isCancelled else { return }
-                                if let cape = appState.appliedCape {
-                                    appState.applyCape(cape)
-                                }
-                            }
+                            // In global mode, CGSSetCursorScale already handles scaling
+                            // — no need to re-register all cursors
                         }
 
                         Text("Scale changes are applied immediately.")

--- a/Mousecape/Mousecape/SwiftUI/Views/SettingsView.swift
+++ b/Mousecape/Mousecape/SwiftUI/Views/SettingsView.swift
@@ -107,15 +107,14 @@ struct GeneralSettingsView: View {
             Section("Cursor Scale") {
                 VStack(alignment: .leading) {
                     Text("\(String(localized:"Global Scale:")) \(cursorScale, specifier: "%.1f")x")
-                    Slider(value: $cursorScale, in: 0.5...2.0, step: 0.1) {
+                    Slider(value: $cursorScale, in: 0.5...16.0, step: 0.1) {
                     } minimumValueLabel: {
                         Text("0.5x")
                     } maximumValueLabel: {
-                        Text("2.0x")
+                        Text("16.0x")
                     }
                     .onChange(of: cursorScale) { _, newValue in
                         saveCursorScale(newValue)
-                        // Apply the cursor scale immediately using the ObjC function
                         _ = setCursorScale(Float(newValue))
                     }
 

--- a/Mousecape/Mousecape/SwiftUI/Views/SettingsView.swift
+++ b/Mousecape/Mousecape/SwiftUI/Views/SettingsView.swift
@@ -64,6 +64,7 @@ struct GeneralSettingsView: View {
     @State private var cursorScale: Double = 1.0
     @State private var scaleMode: ScaleMode = .global
     @State private var isLeftHanded: Bool = false
+    @State private var applyTask: Task<Void, Never>?
     @State private var loginToggleError: String?
     @State private var showLoginError = false
     @Environment(AppState.self) private var appState
@@ -73,6 +74,7 @@ struct GeneralSettingsView: View {
     private static let scaleModeKey = "MCScaleMode"
     private static let perCursorScalesKey = "MCPerCursorScales"
     private static let handednessKey = "MCHandedness"
+    private static let globalCursorScaleKey = "MCGlobalCursorScale"
     private static let preferenceDomain = "com.sdmj76.Mousecape"
 
     var body: some View {
@@ -141,6 +143,15 @@ struct GeneralSettingsView: View {
                         .onChange(of: cursorScale) { _, newValue in
                             saveCursorScale(newValue)
                             _ = setCursorScale(Float(newValue))
+                            // Re-apply cape with new scale (debounced)
+                            applyTask?.cancel()
+                            applyTask = Task { @MainActor in
+                                try? await Task.sleep(for: .milliseconds(500))
+                                guard !Task.isCancelled else { return }
+                                if let cape = appState.appliedCape {
+                                    appState.applyCape(cape)
+                                }
+                            }
                         }
 
                         Text("Scale changes are applied immediately.")
@@ -179,9 +190,8 @@ struct GeneralSettingsView: View {
         .scrollContentBackground(.hidden)
         .navigationTitle("General")
         .onAppear {
-            loadCursorScale()
+            loadScaleMode()  // This now also calls loadCursorScale()
             loadHandedness()
-            loadScaleMode()
         }
         .alert("Login Item Error", isPresented: $showLoginError) {
             Button("OK") { }
@@ -192,15 +202,35 @@ struct GeneralSettingsView: View {
 
     /// Load cursor scale from CFPreferences (same as ObjC code)
     private func loadCursorScale() {
-        if let value = CFPreferencesCopyAppValue(Self.cursorScaleKey as CFString, Self.preferenceDomain as CFString) as? Double {
-            cursorScale = value
+        // In global mode, use the separate global scale preference (not MCCursorScale which custom mode overwrites)
+        if scaleMode == .global {
+            if let value = CFPreferencesCopyAppValue(Self.globalCursorScaleKey as CFString, Self.preferenceDomain as CFString) as? Double {
+                cursorScale = value
+            } else if let value = CFPreferencesCopyAppValue(Self.cursorScaleKey as CFString, Self.preferenceDomain as CFString) as? Double {
+                cursorScale = value
+            } else {
+                cursorScale = 1.0
+            }
         } else {
-            cursorScale = 1.0
+            // In custom mode, show the current system scale (maxScale from MCCursorScale)
+            if let value = CFPreferencesCopyAppValue(Self.cursorScaleKey as CFString, Self.preferenceDomain as CFString) as? Double {
+                cursorScale = value
+            } else {
+                cursorScale = 1.0
+            }
         }
     }
 
     /// Save cursor scale to CFPreferences (same as ObjC code)
     private func saveCursorScale(_ value: Double) {
+        // Save to separate global scale key so custom mode doesn't overwrite it
+        CFPreferencesSetAppValue(
+            Self.globalCursorScaleKey as CFString,
+            value as CFNumber,
+            Self.preferenceDomain as CFString
+        )
+        CFPreferencesAppSynchronize(Self.preferenceDomain as CFString)
+        // Also save to MCCursorScale for applySavedCursorScale() and apply.m
         CFPreferencesSetAppValue(
             Self.cursorScaleKey as CFString,
             value as CFNumber,
@@ -241,6 +271,8 @@ struct GeneralSettingsView: View {
         }
         // CRITICAL: Sync the C global variable so apply.m reads the correct mode
         setCustomScaleMode(scaleMode == .custom)
+        // Reload cursor scale for the current mode
+        loadCursorScale()
     }
 
     /// Save scale mode to CFPreferences

--- a/Mousecape/Mousecape/src/controllers/MCLibraryController.h
+++ b/Mousecape/Mousecape/src/controllers/MCLibraryController.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)removeCape:(MCCursorLibrary *)cape;
 
 - (void)applyCape:(MCCursorLibrary *)cape;
+- (NSDictionary *)applyCapeWithResult:(MCCursorLibrary *)cape;
 - (void)restoreCape;
 
 - (NSURL *)URLForCape:(MCCursorLibrary *)cape;

--- a/Mousecape/Mousecape/src/controllers/MCLibraryController.m
+++ b/Mousecape/Mousecape/src/controllers/MCLibraryController.m
@@ -179,9 +179,17 @@
 }
 
 - (void)applyCape:(MCCursorLibrary *)cape {
-    if (applyCapeAtPath(cape.fileURL.path)) {
+    if (applyCape([cape dictionaryRepresentation])) {
         self.appliedCape = cape;
     }
+}
+
+- (NSDictionary *)applyCapeWithResult:(MCCursorLibrary *)cape {
+    NSDictionary *result = applyCapeWithResult([cape dictionaryRepresentation]);
+    if ([result[@"success"] boolValue]) {
+        self.appliedCape = cape;
+    }
+    return result;
 }
 
 - (void)restoreCape {

--- a/Mousecape/Mousecape/src/models/MCCursor.h
+++ b/Mousecape/Mousecape/src/models/MCCursor.h
@@ -15,7 +15,10 @@ typedef NS_ENUM(NSUInteger, MCCursorScale) {
     MCCursorScale100  = 100,
     MCCursorScale200  = 200,
     MCCursorScale500  = 500,
-    MCCursorScale1000 = 1000
+    MCCursorScale800  = 800,
+    MCCursorScale1000 = 1000,
+    MCCursorScale1600 = 1600,
+    MCCursorScale6400 = 6400,
 };
 
 @interface MCCursor : NSObject <NSCopying>

--- a/Mousecape/mousecloak/MCDefs.h
+++ b/Mousecape/mousecloak/MCDefs.h
@@ -58,7 +58,7 @@ extern const CGFloat   MCMaxHotspotValue;  // Maximum hotspot coordinate value (
 
 // Cursor import limits
 extern const NSUInteger MCMaxFrameCount;   // Maximum animation frame count (24)
-extern const NSInteger  MCMaxImportSize;   // Maximum import image size in pixels (512)
+extern const NSInteger  MCMaxImportSize;   // Maximum import image size in pixels (2048)
 
 extern const CGFloat   MCCursorCreatorVersion;
 extern const CGFloat   MCCursorParserVersion;

--- a/Mousecape/mousecloak/MCDefs.m
+++ b/Mousecape/mousecloak/MCDefs.m
@@ -29,7 +29,7 @@ const CGFloat   MCMaxHotspotValue                    = 31.99;
 
 // Cursor import limits
 const NSUInteger MCMaxFrameCount                     = 24;
-const NSInteger  MCMaxImportSize                     = 512;
+const NSInteger  MCMaxImportSize                     = 2048;
 
 const CGFloat   MCCursorCreatorVersion               = 2.0;
 const CGFloat   MCCursorParserVersion                = 2.0;

--- a/Mousecape/mousecloak/MCPrefs.h
+++ b/Mousecape/mousecloak/MCPrefs.h
@@ -18,6 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString *MCPreferencesAppliedCursorKey;
 extern NSString *MCPreferencesCursorScaleKey;
 extern NSString *MCPreferencesHandednessKey;
+extern NSString *MCPreferencesInnerShadowKey;
+extern NSString *MCPreferencesOuterGlowKey;
+extern NSString *MCPreferencesScaleModeKey;
+extern NSString *MCPreferencesPerCursorScalesKey;
 extern id _Nullable MCDefaultFor(NSString *key, NSString *user, NSString *host);
 extern id _Nullable MCDefault(NSString *key);
 #define MCFlag(key) [MCDefault(key) boolValue]

--- a/Mousecape/mousecloak/MCPrefs.m
+++ b/Mousecape/mousecloak/MCPrefs.m
@@ -12,6 +12,10 @@
 NSString *MCPreferencesAppliedCursorKey          = @"MCAppliedCursor";
 NSString *MCPreferencesCursorScaleKey            = @"MCCursorScale";
 NSString *MCPreferencesHandednessKey             = @"MCHandedness";
+NSString *MCPreferencesInnerShadowKey            = @"MCInnerShadow";
+NSString *MCPreferencesOuterGlowKey             = @"MCOuterGlow";
+NSString *MCPreferencesScaleModeKey             = @"MCScaleMode";
+NSString *MCPreferencesPerCursorScalesKey       = @"MCPerCursorScales";
 
 id MCDefaultFor(NSString *key, NSString *user, NSString *host) {
     NSString *value = (__bridge_transfer NSString *)CFPreferencesCopyValue((__bridge CFStringRef)key, (__bridge CFStringRef)kMCDomain, (__bridge CFStringRef)user, (__bridge CFStringRef)host);

--- a/Mousecape/mousecloak/apply.h
+++ b/Mousecape/mousecloak/apply.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 extern BOOL applyCursorForIdentifier(NSUInteger frameCount, CGFloat frameDuration, CGPoint hotSpot, CGSize size, NSArray *images, NSString *ident, NSUInteger repeatCount);
 extern BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL restore, BOOL customScaleMode);
 extern BOOL applyCape(NSDictionary *dictionary);
+extern NSDictionary *applyCapeWithResult(NSDictionary *dictionary);
 extern BOOL applyCapeAtPath(NSString *path);
 
 NS_ASSUME_NONNULL_END

--- a/Mousecape/mousecloak/apply.h
+++ b/Mousecape/mousecloak/apply.h
@@ -15,7 +15,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 extern BOOL applyCursorForIdentifier(NSUInteger frameCount, CGFloat frameDuration, CGPoint hotSpot, CGSize size, NSArray *images, NSString *ident, NSUInteger repeatCount);
-extern BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL restore);
+extern BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL restore, BOOL customScaleMode);
 extern BOOL applyCape(NSDictionary *dictionary);
 extern BOOL applyCapeAtPath(NSString *path);
 

--- a/Mousecape/mousecloak/apply.m
+++ b/Mousecape/mousecloak/apply.m
@@ -161,6 +161,7 @@ BOOL applyCursorForIdentifier(NSUInteger frameCount, CGFloat frameDuration, CGPo
     return MCRegisterImagesForCursorName(frameCount, frameDuration, hotSpot, size, images, ident);
 }
 
+
 BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL restore) {
     MMLog("=== applyCapeForIdentifier ===");
     MMLog("  Identifier: %s", identifier.UTF8String);
@@ -198,6 +199,9 @@ BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL res
         hotSpot.x = size.width - hotSpot.x - 1;
     }
 
+    // Select only the representation with the highest pixel count
+    NSBitmapImageRep *bestRep = nil;
+    NSUInteger bestPixelCount = 0;
     for (id object in reps) {
         CFTypeID type = CFGetTypeID((__bridge CFTypeRef)object);
         NSBitmapImageRep *rep;
@@ -208,45 +212,46 @@ BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL res
         }
         rep = rep.retaggedSRGBSpace;
 
+        NSUInteger pixelCount = (NSUInteger)rep.pixelsWide * (NSUInteger)rep.pixelsHigh;
+        if (pixelCount > bestPixelCount) {
+            bestPixelCount = pixelCount;
+            bestRep = rep;
+        }
+    }
+
+    if (bestRep) {
         if (!lefty || restore) {
-            // special case if array has a type of CGImage already there is no need to convert it
-            if (type == CGImageGetTypeID()) {
-                images[images.count] = object;
-                continue;
-            }
-
-            images[images.count] = (__bridge id)[rep CGImage];
-
+            images[images.count] = (__bridge id)[bestRep CGImage];
         } else {
             NSBitmapImageRep *newRep = [[NSBitmapImageRep alloc] initWithBitmapDataPlanes:NULL
-                                                                               pixelsWide:rep.pixelsWide
-                                                                               pixelsHigh:rep.pixelsHigh
+                                                                               pixelsWide:bestRep.pixelsWide
+                                                                               pixelsHigh:bestRep.pixelsHigh
                                                                             bitsPerSample:8
                                                                           samplesPerPixel:4
                                                                                  hasAlpha:YES
                                                                                  isPlanar:NO
                                                                            colorSpaceName:NSCalibratedRGBColorSpace
-                                                                              bytesPerRow:4 * rep.pixelsWide
+                                                                              bytesPerRow:4 * bestRep.pixelsWide
                                                                              bitsPerPixel:32];
             NSGraphicsContext *ctx = [NSGraphicsContext graphicsContextWithBitmapImageRep:newRep];
             [NSGraphicsContext saveGraphicsState];
             [NSGraphicsContext setCurrentContext:ctx];
             NSAffineTransform *transform = [NSAffineTransform transform];
-            [transform translateXBy:rep.pixelsWide yBy:0];
+            [transform translateXBy:bestRep.pixelsWide yBy:0];
             [transform scaleXBy:-1 yBy:1];
             [transform concat];
 
-            [rep drawInRect:NSMakeRect(0, 0, rep.pixelsWide, rep.pixelsHigh)
-                   fromRect:NSZeroRect
-                  operation:NSCompositingOperationSourceOver
-                   fraction:1.0
-             respectFlipped:NO
-                      hints:nil];
+            [bestRep drawInRect:NSMakeRect(0, 0, bestRep.pixelsWide, bestRep.pixelsHigh)
+                       fromRect:NSZeroRect
+                      operation:NSCompositingOperationSourceOver
+                       fraction:1.0
+                respectFlipped:NO
+                         hints:nil];
             [NSGraphicsContext restoreGraphicsState];
             images[images.count] = (__bridge id)[newRep CGImage];
         }
     }
-    
+
     return applyCursorForIdentifier(frameCount.unsignedIntegerValue, frameDuration.doubleValue, hotSpot, size, images, identifier, 0);
 }
 

--- a/Mousecape/mousecloak/apply.m
+++ b/Mousecape/mousecloak/apply.m
@@ -204,9 +204,25 @@ BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL res
         hotSpot.x = size.width - hotSpot.x - 1;
     }
 
-    // Select only the representation with the highest pixel count
+    // Calculate effective scale for representation selection
+    // Pick the representation whose pixel size best matches the target render size
+    float effectiveScale = 1.0f;
+    if (customScaleMode) {
+        NSDictionary *perCursorScales = MCDefault(MCPreferencesPerCursorScalesKey);
+        float desiredScale = [perCursorScales[identifier] floatValue];
+        if (desiredScale > 0.0f) effectiveScale = desiredScale;
+    } else {
+        effectiveScale = cursorScale();
+        if (effectiveScale <= 0.0f) effectiveScale = 1.0f;
+    }
+    NSUInteger targetPixelCount = (NSUInteger)(size.width * effectiveScale) * (NSUInteger)(size.height * effectiveScale);
+    MMLog("  Effective scale: %.2f, target pixel count: %lu", effectiveScale, (unsigned long)targetPixelCount);
+
+    // Select the representation closest to the target pixel size
+    // (instead of always picking the highest resolution)
     NSBitmapImageRep *bestRep = nil;
     NSUInteger bestPixelCount = 0;
+    NSUInteger bestDistance = UINT_MAX;
     for (id object in reps) {
         CFTypeID type = CFGetTypeID((__bridge CFTypeRef)object);
         NSBitmapImageRep *rep;
@@ -218,11 +234,17 @@ BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL res
         rep = rep.retaggedSRGBSpace;
 
         NSUInteger pixelCount = (NSUInteger)rep.pixelsWide * (NSUInteger)rep.pixelsHigh;
-        if (pixelCount > bestPixelCount) {
+        NSUInteger distance = (pixelCount > targetPixelCount) ?
+            (pixelCount - targetPixelCount) : (targetPixelCount - pixelCount);
+        // Prefer closest match; tie-break by higher pixel count
+        if (distance < bestDistance || (distance == bestDistance && pixelCount > bestPixelCount)) {
+            bestDistance = distance;
             bestPixelCount = pixelCount;
             bestRep = rep;
         }
     }
+    MMLog("  Selected representation: %lupx (distance: %lu from target %lupx)",
+          (unsigned long)bestPixelCount, (unsigned long)bestDistance, (unsigned long)targetPixelCount);
 
     if (bestRep) {
         if (!lefty || restore) {
@@ -296,11 +318,12 @@ BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL res
 
         float maxScale = cursorScale(); // Read current system scale directly from CGS
         if (maxScale <= 0.0f) maxScale = 1.0f;
+        float ratio = (maxScale > 0) ? desiredScale / maxScale : 1.0f;
         MMLog("SCALE DEBUG per-cursor %s: desired=%.2f, maxScale=%.2f, ratio=%.3f",
-              identifier.UTF8String, desiredScale, maxScale, (maxScale > 0 ? desiredScale/maxScale : 0));
+              identifier.UTF8String, desiredScale, maxScale, ratio);
 
-        if (desiredScale < maxScale) {
-            float ratio = desiredScale / maxScale;
+        // Scale when ratio differs from 1.0 (handles both down-scaling AND up-scaling)
+        if (ratio < 0.99f || ratio > 1.01f) {
             // Scale the logical size proportionally so the cursor appears at the correct visual size
             size = CGSizeMake(size.width * ratio, size.height * ratio);
             MMLog("Custom scaling %s: desired=%.2f, max=%.2f, ratio=%.3f, newSize=%.1fx%.1f",
@@ -333,6 +356,10 @@ BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL res
             }
             CGColorSpaceRelease(scaleColorSpace);
             images = scaledImages;
+
+            // Scale hotspot proportionally with the image to maintain correct position
+            hotSpot = CGPointMake(hotSpot.x * ratio, hotSpot.y * ratio);
+            MMLog("Hotspot scaled by ratio %.3f: (%.1f, %.1f)", ratio, hotSpot.x, hotSpot.y);
         }
     }
 
@@ -442,6 +469,109 @@ BOOL applyCape(NSDictionary *dictionary) {
         MMLog("========================================");
 
         return YES;
+    }
+}
+
+NSDictionary *applyCapeWithResult(NSDictionary *dictionary) {
+    @autoreleasepool {
+        NSDictionary *cursors = dictionary[MCCursorDictionaryCursorsKey];
+        NSString *name = dictionary[MCCursorDictionaryCapeNameKey];
+        NSNumber *version = dictionary[MCCursorDictionaryCapeVersionKey];
+
+        MMLog("========================================");
+        MMLog("=== APPLYING CAPE WITH RESULT ===");
+        MMLog("========================================");
+        MMLog("Cape name: %s", name.UTF8String);
+        MMLog("Cape identifier: %s", [dictionary[MCCursorDictionaryIdentifierKey] UTF8String]);
+        MMLog("Total cursors: %lu", (unsigned long)cursors.count);
+
+        // Save the current system scale BEFORE resetAllCursors() might reset it
+        float savedScale = cursorScale();
+        MMLog("Saved system scale before reset: %.2f", savedScale);
+
+        MMLog("--- Calling resetAllCursors ---");
+        resetAllCursors();
+        MMLog("--- Calling backupAllCursors ---");
+        backupAllCursors();
+
+        // Read scale mode from direct C variable (not CFPreferences)
+        BOOL isCustomMode = customScaleMode();
+
+        if (isCustomMode) {
+            float maxScale = 1.0f;
+            NSDictionary *perCursorScales = MCDefault(MCPreferencesPerCursorScalesKey);
+            if (perCursorScales) {
+                for (NSNumber *val in perCursorScales.allValues) {
+                    float s = val.floatValue;
+                    if (s > maxScale) maxScale = s;
+                }
+            }
+            MMLog("SCALE DEBUG: custom mode, maxScale=%.2f", maxScale);
+            setCursorScale(maxScale);
+            // Save maxScale as MCCursorScale so listen.m can restore it
+            MCSetDefault(@(maxScale), MCPreferencesCursorScaleKey);
+        } else {
+            MMLog("SCALE DEBUG: global mode, restoring to %.2f", savedScale);
+            if (savedScale >= 0.5f && savedScale <= 16.0f) {
+                setCursorScale(savedScale);
+            } else {
+                setCursorScale(defaultCursorScale());
+            }
+        }
+
+        MMLog("--- Applying cursors ---");
+
+        NSUInteger successCount = 0;
+        NSUInteger skippedCount = 0;
+        NSUInteger failedCount = 0;
+        NSMutableArray *failedIdentifiers = [NSMutableArray array];
+        NSMutableArray *skippedIdentifiers = [NSMutableArray array];
+
+        for (NSString *key in cursors) {
+            NSDictionary *cape = cursors[key];
+            MMLog("Hooking for %s", key.UTF8String);
+
+            // Check if cursor has valid image data before attempting to apply
+            NSArray *reps = cape[MCCursorDictionaryRepresentationsKey];
+            if (!reps || reps.count == 0) {
+                MMLog(YELLOW "  Skipping cursor %s - no image data" RESET, key.UTF8String);
+                skippedCount++;
+                [skippedIdentifiers addObject:key];
+                continue;
+            }
+
+            BOOL success = applyCapeForIdentifier(cape, key, NO, isCustomMode);
+            if (!success) {
+                MMLog(YELLOW "  Failed to apply cursor %s" RESET, key.UTF8String);
+                failedCount++;
+                [failedIdentifiers addObject:key];
+            } else {
+                successCount++;
+            }
+        }
+
+        MMLog("--- Application Summary ---");
+        MMLog("  Total cursors: %lu", (unsigned long)cursors.count);
+        MMLog("  Successfully applied: %lu", (unsigned long)successCount);
+        MMLog("  Skipped (no images): %lu", (unsigned long)skippedCount);
+        MMLog("  Failed: %lu", (unsigned long)failedCount);
+
+        // Only save applied cursor preference if at least one cursor succeeded
+        if (successCount > 0) {
+            MCSetDefault(dictionary[MCCursorDictionaryIdentifierKey], MCPreferencesAppliedCursorKey);
+        }
+
+        MMLog("========================================");
+
+        // Return detailed result dictionary
+        return @{
+            @"success": @(successCount > 0),
+            @"successCount": @(successCount),
+            @"skippedCount": @(skippedCount),
+            @"failedCount": @(failedCount),
+            @"failedIdentifiers": [failedIdentifiers copy],
+            @"skippedIdentifiers": [skippedIdentifiers copy]
+        };
     }
 }
 

--- a/Mousecape/mousecloak/apply.m
+++ b/Mousecape/mousecloak/apply.m
@@ -12,6 +12,9 @@
 #import "MCPrefs.h"
 #import "NSBitmapImageRep+ColorSpace.h"
 #import "MCDefs.h"
+#import "innerShadow.h"
+#import "outerGlow.h"
+#import "scale.h"
 
 static BOOL MCRegisterImagesForCursorName(NSUInteger frameCount, CGFloat frameDuration, CGPoint hotSpot, CGSize size, NSArray *images, NSString *name) {
     char *cursorName = (char *)name.UTF8String;
@@ -162,7 +165,7 @@ BOOL applyCursorForIdentifier(NSUInteger frameCount, CGFloat frameDuration, CGPo
 }
 
 
-BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL restore) {
+BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL restore, BOOL customScaleMode) {
     MMLog("=== applyCapeForIdentifier ===");
     MMLog("  Identifier: %s", identifier.UTF8String);
     MMLog("  Restore mode: %s", restore ? "YES" : "NO");
@@ -173,6 +176,8 @@ BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL res
     }
 
     BOOL lefty = MCFlag(MCPreferencesHandednessKey);
+    BOOL innerShadow = MCFlag(MCPreferencesInnerShadowKey);
+    BOOL outerGlow = MCFlag(MCPreferencesOuterGlowKey);
     BOOL pointer = MCCursorIsPointer(identifier);
     NSNumber *frameCount    = cursor[MCCursorDictionaryFrameCountKey];
     NSNumber *frameDuration = cursor[MCCursorDictionaryFrameDuratiomKey];
@@ -252,6 +257,85 @@ BOOL applyCapeForIdentifier(NSDictionary *cursor, NSString *identifier, BOOL res
         }
     }
 
+    // Apply inner shadow effect if enabled
+    if (innerShadow && images.count > 0) {
+        float radius = 32.0f;
+        float intensity = 0.6f;
+        MMLog("Applying inner shadow effect (radius=%.1f, intensity=%.1f)", radius, intensity);
+        NSMutableArray *processed = [NSMutableArray arrayWithCapacity:images.count];
+        for (id imgObj in images) {
+            CGImageRef original = (__bridge CGImageRef)imgObj;
+            CGImageRef shadowed = MCApplyInnerShadow(original, radius, intensity);
+            [processed addObject:(__bridge id)(shadowed ?: original)];
+            if (shadowed) CGImageRelease(shadowed);
+        }
+        images = processed;
+    }
+
+    // Apply outer glow effect if enabled
+    if (outerGlow && images.count > 0) {
+        float radius = 40.0f;
+        float intensity = 0.7f;
+        MMLog("Applying outer glow effect (radius=%.1f, intensity=%.1f)", radius, intensity);
+        NSMutableArray *processed = [NSMutableArray arrayWithCapacity:images.count];
+        for (id imgObj in images) {
+            CGImageRef original = (__bridge CGImageRef)imgObj;
+            CGImageRef glowing = MCApplyOuterGlow(original, radius, intensity);
+            [processed addObject:(__bridge id)(glowing ?: original)];
+            if (glowing) CGImageRelease(glowing);
+        }
+        images = processed;
+    }
+
+    // Per-cursor custom scaling
+    if (customScaleMode) {
+        NSDictionary *perCursorScales = MCDefault(MCPreferencesPerCursorScalesKey);
+        MMLog("SCALE DEBUG per-cursor %s: perCursorScales=%@, customMode=YES", identifier.UTF8String, perCursorScales);
+        float desiredScale = [perCursorScales[identifier] floatValue];
+        if (desiredScale <= 0.0f) desiredScale = 1.0f;
+
+        float maxScale = cursorScale(); // Read current system scale directly from CGS
+        if (maxScale <= 0.0f) maxScale = 1.0f;
+        MMLog("SCALE DEBUG per-cursor %s: desired=%.2f, maxScale=%.2f, ratio=%.3f",
+              identifier.UTF8String, desiredScale, maxScale, (maxScale > 0 ? desiredScale/maxScale : 0));
+
+        if (desiredScale < maxScale) {
+            float ratio = desiredScale / maxScale;
+            // Scale the logical size proportionally so the cursor appears at the correct visual size
+            size = CGSizeMake(size.width * ratio, size.height * ratio);
+            MMLog("Custom scaling %s: desired=%.2f, max=%.2f, ratio=%.3f, newSize=%.1fx%.1f",
+                  identifier.UTF8String, desiredScale, maxScale, ratio, size.width, size.height);
+
+            CGColorSpaceRef scaleColorSpace = CGColorSpaceCreateDeviceRGB();
+            NSMutableArray *scaledImages = [NSMutableArray arrayWithCapacity:images.count];
+            for (id imgObj in images) {
+                CGImageRef original = (__bridge CGImageRef)imgObj;
+                size_t w = CGImageGetWidth(original);
+                size_t h = CGImageGetHeight(original);
+                size_t newW = MAX((size_t)(w * ratio + 0.5f), 1);
+                size_t newH = MAX((size_t)(h * ratio + 0.5f), 1);
+
+                CGContextRef ctx = CGBitmapContextCreate(
+                    nil, newW, newH, 8, newW * 4,
+                    scaleColorSpace,
+                    kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Big
+                );
+                if (ctx) {
+                    CGContextDrawImage(ctx, CGRectMake(0, 0, newW, newH), original);
+                    CGImageRef scaledImg = CGBitmapContextCreateImage(ctx);
+                    CGContextRelease(ctx);
+                    [scaledImages addObject:(__bridge id)(scaledImg ?: original)];
+                    if (scaledImg) CGImageRelease(scaledImg);
+                } else {
+                    MMLog("Failed to create scaling context for %s", identifier.UTF8String);
+                    [scaledImages addObject:imgObj];
+                }
+            }
+            CGColorSpaceRelease(scaleColorSpace);
+            images = scaledImages;
+        }
+    }
+
     return applyCursorForIdentifier(frameCount.unsignedIntegerValue, frameDuration.doubleValue, hotSpot, size, images, identifier, 0);
 }
 
@@ -273,10 +357,40 @@ BOOL applyCape(NSDictionary *dictionary) {
             MMLog("  - %s", key.UTF8String);
         }
 
+        // Save the current system scale BEFORE resetAllCursors() might reset it
+        float savedScale = cursorScale();
+        MMLog("Saved system scale before reset: %.2f", savedScale);
+
         MMLog("--- Calling resetAllCursors ---");
         resetAllCursors();
         MMLog("--- Calling backupAllCursors ---");
         backupAllCursors();
+
+        // Read scale mode from direct C variable (not CFPreferences)
+        BOOL isCustomMode = customScaleMode();
+
+        if (isCustomMode) {
+            float maxScale = 1.0f;
+            NSDictionary *perCursorScales = MCDefault(MCPreferencesPerCursorScalesKey);
+            if (perCursorScales) {
+                for (NSNumber *val in perCursorScales.allValues) {
+                    float s = val.floatValue;
+                    if (s > maxScale) maxScale = s;
+                }
+            }
+            MMLog("SCALE DEBUG: custom mode, maxScale=%.2f", maxScale);
+            setCursorScale(maxScale);
+            // Save maxScale as MCCursorScale so listen.m can restore it
+            MCSetDefault(@(maxScale), MCPreferencesCursorScaleKey);
+        } else {
+            // Global mode: restore the exact scale that was active before reset
+            MMLog("SCALE DEBUG: global mode, restoring to %.2f", savedScale);
+            if (savedScale >= 0.5f && savedScale <= 16.0f) {
+                setCursorScale(savedScale);
+            } else {
+                setCursorScale(defaultCursorScale());
+            }
+        }
 
         MMLog("--- Applying cursors ---");
 
@@ -296,7 +410,7 @@ BOOL applyCape(NSDictionary *dictionary) {
                 continue;
             }
 
-            BOOL success = applyCapeForIdentifier(cape, key, NO);
+            BOOL success = applyCapeForIdentifier(cape, key, NO, isCustomMode);
             if (!success) {
                 MMLog(YELLOW "  Failed to apply cursor %s - continuing with remaining cursors..." RESET, key.UTF8String);
                 failedCount++;

--- a/Mousecape/mousecloak/backup.m
+++ b/Mousecape/mousecloak/backup.m
@@ -35,7 +35,7 @@ void backupCursorForIdentifier(NSString *ident) {
     }
 
     NSDictionary *cape = capeWithIdentifier(ident);
-    BOOL success = applyCapeForIdentifier(cape, backupIdent, YES);
+    BOOL success = applyCapeForIdentifier(cape, backupIdent, YES, NO);
     MMLog("    Backup result: %s", success ? "SUCCESS" : "FAILED");
 }
 

--- a/Mousecape/mousecloak/innerShadow.h
+++ b/Mousecape/mousecloak/innerShadow.h
@@ -1,0 +1,10 @@
+#import <CoreGraphics/CoreGraphics.h>
+
+/// Applies an inner shadow effect to a cursor image.
+/// Darkens pixels near the edges of the cursor shape from inside.
+/// @param image The source CGImage (typically RGBA, 8-bpc)
+/// @param radius Shadow radius in pixels (blur spread). Default 4.0.
+/// @param intensity Shadow darkness 0.0-1.0. Default 0.4.
+/// @return A new CGImage with inner shadow applied. Caller must CGImageRelease.
+///         Returns NULL if the input is invalid or processing fails.
+CGImageRef MCApplyInnerShadow(CGImageRef image, float radius, float intensity);

--- a/Mousecape/mousecloak/innerShadow.m
+++ b/Mousecape/mousecloak/innerShadow.m
@@ -1,0 +1,187 @@
+#import "innerShadow.h"
+#import "MCDefs.h"
+#import <Accelerate/Accelerate.h>
+
+CGImageRef MCApplyInnerShadow(CGImageRef image, float radius, float intensity) {
+    @autoreleasepool {
+
+        // --- Step 1: Validate input ---
+        if (!image) {
+            MMLog("MCApplyInnerShadow: image is NULL");
+            return NULL;
+        }
+
+        size_t width = CGImageGetWidth(image);
+        size_t height = CGImageGetHeight(image);
+
+        if (width == 0 || height == 0) {
+            MMLog("MCApplyInnerShadow: image has zero dimensions (%zux%zu)", width, height);
+            return NULL;
+        }
+
+        // Clamp radius to at least 1.0
+        int blurRadius = (int)radius;
+        if (blurRadius < 1) {
+            blurRadius = 1;
+        }
+
+        // Clamp intensity
+        if (intensity < 0.0f) intensity = 0.0f;
+        if (intensity > 1.0f) intensity = 1.0f;
+
+        MMLog("MCApplyInnerShadow: processing %zux%zu image, radius=%d, intensity=%.2f",
+              width, height, blurRadius, intensity);
+
+        // --- Step 2: Create pixel buffer (8-bpc RGBA, non-premultiplied) ---
+        CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+        if (!colorSpace) {
+            MMLog("MCApplyInnerShadow: failed to create color space");
+            return NULL;
+        }
+
+        // kCGImageAlphaPremultipliedLast = RGBA byte order, non-premultiplied rendering
+        // We draw into this context which normalizes the pixel format.
+        CGContextRef context = CGBitmapContextCreate(
+            nil,
+            width,
+            height,
+            8,
+            width * 4,
+            colorSpace,
+            kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Big
+        );
+        CGColorSpaceRelease(colorSpace);
+
+        if (!context) {
+            MMLog("MCApplyInnerShadow: failed to create bitmap context");
+            return NULL;
+        }
+
+        // Draw source image into our normalized context
+        CGRect rect = CGRectMake(0, 0, width, height);
+        CGContextDrawImage(context, rect, image);
+
+        // Get mutable pixel data
+        uint8_t *pixels = (uint8_t *)CGBitmapContextGetData(context);
+        if (!pixels) {
+            MMLog("MCApplyInnerShadow: failed to get pixel data from context");
+            CGContextRelease(context);
+            return NULL;
+        }
+
+        size_t totalPixels = width * height;
+
+        // --- Step 3: Extract alpha channel ---
+        // Pixel format: ARGB (premultiplied first, big endian)
+        // Byte order: A, R, G, B per pixel
+        float *alpha = (float *)malloc(totalPixels * sizeof(float));
+        if (!alpha) {
+            MMLog("MCApplyInnerShadow: failed to allocate alpha buffer");
+            CGContextRelease(context);
+            return NULL;
+        }
+
+        for (size_t i = 0; i < totalPixels; i++) {
+            alpha[i] = pixels[i * 4] / 255.0f; // Alpha is at byte offset 0 (premultiplied first)
+        }
+
+        // --- Step 4: Box blur the alpha using Accelerate vImage (3-pass separable) ---
+        float *temp = (float *)malloc(totalPixels * sizeof(float));
+        float *blurred = (float *)malloc(totalPixels * sizeof(float));
+
+        if (!temp || !blurred) {
+            MMLog("%s: failed to allocate blur buffers", __func__);
+            free(alpha);
+            if (temp) free(temp);
+            if (blurred) free(blurred);
+            CGContextRelease(context);
+            return NULL;
+        }
+
+        int kSize = blurRadius * 2 + 1;
+        float invK = 1.0f / kSize;
+
+        // Create a uniform 1D kernel (all invK) — pre-divided so convolution result is averaged
+        float *kernel = (float *)malloc(kSize * sizeof(float));
+        if (!kernel) {
+            MMLog("%s: failed to allocate kernel", __func__);
+            free(alpha);
+            free(temp);
+            free(blurred);
+            CGContextRelease(context);
+            return NULL;
+        }
+        for (int i = 0; i < kSize; i++) {
+            kernel[i] = invK;
+        }
+
+        // Set up vImage buffers
+        vImage_Buffer srcBuf = { alpha, height, width, width * sizeof(float) };
+        vImage_Buffer tempBuf = { temp, height, width, width * sizeof(float) };
+        vImage_Buffer blurBuf = { blurred, height, width, width * sizeof(float) };
+
+        // Pass 1: Horizontal — alpha → temp
+        vImageConvolve_PlanarF(&srcBuf, &tempBuf, NULL, 0, 0,
+                               kernel, 1, kSize, 0.0f,
+                               kvImageEdgeExtend);
+
+        // Pass 2: Vertical — temp → blurred
+        vImageConvolve_PlanarF(&tempBuf, &blurBuf, NULL, 0, 0,
+                               kernel, kSize, 1, 0.0f,
+                               kvImageEdgeExtend);
+
+        // Pass 3: Horizontal — blurred → temp
+        vImageConvolve_PlanarF(&blurBuf, &tempBuf, NULL, 0, 0,
+                               kernel, 1, kSize, 0.0f,
+                               kvImageEdgeExtend);
+
+        free(kernel);
+
+        // temp now holds the final 3-pass blurred alpha
+        float *blurredAlpha = temp;
+
+        // --- Step 5: Compute shadow and darken pixels ---
+        for (size_t i = 0; i < totalPixels; i++) {
+            float shadow = alpha[i] - blurredAlpha[i];
+            if (shadow < 0.0f) shadow = 0.0f;
+            if (shadow > 1.0f) shadow = 1.0f;
+            shadow *= intensity;
+
+            float darkening = shadow * 255.0f;
+
+            // Pixel layout: A(0), R(1), G(2), B(3) — premultiplied first, big endian
+            float r = pixels[i * 4 + 1] - darkening;
+            float g = pixels[i * 4 + 2] - darkening;
+            float b = pixels[i * 4 + 3] - darkening;
+
+            // Clamp RGB to [0, 255]
+            if (r < 0.0f) r = 0.0f;
+            if (r > 255.0f) r = 255.0f;
+            if (g < 0.0f) g = 0.0f;
+            if (g > 255.0f) g = 255.0f;
+            if (b < 0.0f) b = 0.0f;
+            if (b > 255.0f) b = 255.0f;
+
+            // Write back — alpha unchanged
+            pixels[i * 4 + 1] = (uint8_t)(r + 0.5f); // round to nearest
+            pixels[i * 4 + 2] = (uint8_t)(g + 0.5f);
+            pixels[i * 4 + 3] = (uint8_t)(b + 0.5f);
+        }
+
+        // --- Step 6: Create output CGImage ---
+        CGImageRef outputImage = CGBitmapContextCreateImage(context);
+
+        // --- Step 7: Clean up ---
+        free(alpha);
+        free(temp);
+        free(blurred);
+        CGContextRelease(context);
+
+        if (!outputImage) {
+            MMLog("MCApplyInnerShadow: failed to create output image");
+            return NULL;
+        }
+
+        return outputImage;
+    } // @autoreleasepool
+}

--- a/Mousecape/mousecloak/listen.m
+++ b/Mousecape/mousecloak/listen.m
@@ -85,8 +85,18 @@ static void UserSpaceChanged(SCDynamicStoreRef	store, CFArrayRef changedKeys, vo
         MMLog("No cape configured for user");
     }
 
-    setCursorScale(defaultCursorScale());
-    MMLog("Cursor scale applied");
+    // Restore scale according to the active mode
+    if (customScaleMode()) {
+        float maxScale = [MCDefault(MCPreferencesCursorScaleKey) floatValue];
+        if (maxScale <= 0.0f) maxScale = 1.0f;
+        MMLog("Session monitor: restoring custom scale %.2f", maxScale);
+        setCursorScale(maxScale);
+    } else {
+        float globalScale = [MCDefault(@"MCGlobalCursorScale") floatValue];
+        if (globalScale < 0.5f || globalScale > 16.0f) globalScale = 1.0f;
+        MMLog("Session monitor: restoring global scale %.2f", globalScale);
+        setCursorScale(globalScale);
+    }
 
     CFRelease(currentConsoleUser);
 }
@@ -180,8 +190,16 @@ void listener(void) {
     } else {
         MMLog("No cape configured - running in standby mode");
     }
-    setCursorScale(defaultCursorScale());
-    MMLog("Initial cursor scale applied");
+    // Restore scale according to the active mode
+    if (customScaleMode()) {
+        float maxScale = [MCDefault(MCPreferencesCursorScaleKey) floatValue];
+        if (maxScale <= 0.0f) maxScale = 1.0f;
+        setCursorScale(maxScale);
+    } else {
+        float globalScale = [MCDefault(@"MCGlobalCursorScale") floatValue];
+        if (globalScale < 0.5f || globalScale > 16.0f) globalScale = 1.0f;
+        setCursorScale(globalScale);
+    }
 
     CFRunLoopAddSource(CFRunLoopGetCurrent(), rls, kCFRunLoopDefaultMode);
     MMLog("Entering run loop...");
@@ -232,8 +250,18 @@ void startSessionMonitor(void) {
     } else {
         MMLog("No cape configured - running in standby mode");
     }
-    setCursorScale(defaultCursorScale());
-    MMLog("Initial cursor scale applied");
+    // Restore scale according to the active mode
+    if (customScaleMode()) {
+        float maxScale = [MCDefault(MCPreferencesCursorScaleKey) floatValue];
+        if (maxScale <= 0.0f) maxScale = 1.0f;
+        MMLog("Session monitor: restoring custom scale %.2f", maxScale);
+        setCursorScale(maxScale);
+    } else {
+        float globalScale = [MCDefault(@"MCGlobalCursorScale") floatValue];
+        if (globalScale < 0.5f || globalScale > 16.0f) globalScale = 1.0f;
+        MMLog("Session monitor: restoring global scale %.2f", globalScale);
+        setCursorScale(globalScale);
+    }
 
     CFRunLoopAddSource(CFRunLoopGetMain(), rls, kCFRunLoopDefaultMode);
     MMLog("Session monitor attached to main run loop (non-blocking)");

--- a/Mousecape/mousecloak/outerGlow.h
+++ b/Mousecape/mousecloak/outerGlow.h
@@ -1,0 +1,10 @@
+#import <CoreGraphics/CoreGraphics.h>
+
+/// Applies an outer glow effect to a cursor image.
+/// Adds a soft white halo around the cursor shape edges for better visibility.
+/// @param image The source CGImage (typically RGBA, 8-bpc)
+/// @param radius Glow radius in pixels (blur spread). Default 6.0.
+/// @param intensity Glow opacity 0.0-1.0. Default 0.5.
+/// @return A new CGImage with outer glow applied. Caller must CGImageRelease.
+///         Returns NULL if the input is invalid or processing fails.
+CGImageRef MCApplyOuterGlow(CGImageRef image, float radius, float intensity);

--- a/Mousecape/mousecloak/outerGlow.m
+++ b/Mousecape/mousecloak/outerGlow.m
@@ -1,0 +1,180 @@
+#import "outerGlow.h"
+#import "MCDefs.h"
+#import <Accelerate/Accelerate.h>
+
+CGImageRef MCApplyOuterGlow(CGImageRef image, float radius, float intensity) {
+    @autoreleasepool {
+
+        // --- Step 1: Validate input ---
+        if (!image) {
+            MMLog("MCApplyOuterGlow: image is NULL");
+            return NULL;
+        }
+
+        size_t width = CGImageGetWidth(image);
+        size_t height = CGImageGetHeight(image);
+
+        if (width == 0 || height == 0) {
+            MMLog("MCApplyOuterGlow: image has zero dimensions (%zux%zu)", width, height);
+            return NULL;
+        }
+
+        // Clamp radius to at least 1.0
+        int blurRadius = (int)radius;
+        if (blurRadius < 1) {
+            blurRadius = 1;
+        }
+
+        // Clamp intensity
+        if (intensity < 0.0f) intensity = 0.0f;
+        if (intensity > 1.0f) intensity = 1.0f;
+
+        MMLog("MCApplyOuterGlow: processing %zux%zu image, radius=%d, intensity=%.2f",
+              width, height, blurRadius, intensity);
+
+        // --- Step 2: Create pixel buffer (8-bpc RGBA, non-premultiplied) ---
+        CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+        if (!colorSpace) {
+            MMLog("MCApplyOuterGlow: failed to create color space");
+            return NULL;
+        }
+
+        CGContextRef context = CGBitmapContextCreate(
+            nil,
+            width,
+            height,
+            8,
+            width * 4,
+            colorSpace,
+            kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Big
+        );
+        CGColorSpaceRelease(colorSpace);
+
+        if (!context) {
+            MMLog("MCApplyOuterGlow: failed to create bitmap context");
+            return NULL;
+        }
+
+        // Draw source image into our normalized context
+        CGRect rect = CGRectMake(0, 0, width, height);
+        CGContextDrawImage(context, rect, image);
+
+        // Get mutable pixel data
+        uint8_t *pixels = (uint8_t *)CGBitmapContextGetData(context);
+        if (!pixels) {
+            MMLog("MCApplyOuterGlow: failed to get pixel data from context");
+            CGContextRelease(context);
+            return NULL;
+        }
+
+        size_t totalPixels = width * height;
+
+        // --- Step 3: Extract alpha channel ---
+        // Pixel format: ARGB (premultiplied first, big endian)
+        // Byte order: A, R, G, B per pixel
+        float *alpha = (float *)malloc(totalPixels * sizeof(float));
+        if (!alpha) {
+            MMLog("MCApplyOuterGlow: failed to allocate alpha buffer");
+            CGContextRelease(context);
+            return NULL;
+        }
+
+        for (size_t i = 0; i < totalPixels; i++) {
+            alpha[i] = pixels[i * 4] / 255.0f; // Alpha is at byte offset 0 (premultiplied first)
+        }
+
+        // --- Step 4: Box blur the alpha using Accelerate vImage (3-pass separable) ---
+        float *temp = (float *)malloc(totalPixels * sizeof(float));
+        float *blurred = (float *)malloc(totalPixels * sizeof(float));
+
+        if (!temp || !blurred) {
+            MMLog("%s: failed to allocate blur buffers", __func__);
+            free(alpha);
+            if (temp) free(temp);
+            if (blurred) free(blurred);
+            CGContextRelease(context);
+            return NULL;
+        }
+
+        int kSize = blurRadius * 2 + 1;
+        float invK = 1.0f / kSize;
+
+        // Create a uniform 1D kernel (all invK) — pre-divided so convolution result is averaged
+        float *kernel = (float *)malloc(kSize * sizeof(float));
+        if (!kernel) {
+            MMLog("%s: failed to allocate kernel", __func__);
+            free(alpha);
+            free(temp);
+            free(blurred);
+            CGContextRelease(context);
+            return NULL;
+        }
+        for (int i = 0; i < kSize; i++) {
+            kernel[i] = invK;
+        }
+
+        // Set up vImage buffers
+        vImage_Buffer srcBuf = { alpha, height, width, width * sizeof(float) };
+        vImage_Buffer tempBuf = { temp, height, width, width * sizeof(float) };
+        vImage_Buffer blurBuf = { blurred, height, width, width * sizeof(float) };
+
+        // Pass 1: Horizontal — alpha → temp
+        vImageConvolve_PlanarF(&srcBuf, &tempBuf, NULL, 0, 0,
+                               kernel, 1, kSize, 0.0f,
+                               kvImageEdgeExtend);
+
+        // Pass 2: Vertical — temp → blurred
+        vImageConvolve_PlanarF(&tempBuf, &blurBuf, NULL, 0, 0,
+                               kernel, kSize, 1, 0.0f,
+                               kvImageEdgeExtend);
+
+        // Pass 3: Horizontal — blurred → temp
+        vImageConvolve_PlanarF(&blurBuf, &tempBuf, NULL, 0, 0,
+                               kernel, 1, kSize, 0.0f,
+                               kvImageEdgeExtend);
+
+        free(kernel);
+
+        // temp now holds the final 3-pass blurred alpha
+        float *blurredAlpha = temp;
+
+        // --- Step 5: Compute outer glow and apply ---
+        for (size_t i = 0; i < totalPixels; i++) {
+            float glow = blurredAlpha[i] - alpha[i];
+            if (glow < 0.0f) glow = 0.0f;
+            if (glow > 1.0f) glow = 1.0f;
+            glow *= intensity;
+
+            // Pixel layout: A(0), R(1), G(2), B(3) — premultiplied first, big endian
+            if (alpha[i] > 0.0f) {
+                // Inside the cursor shape: keep original pixel unchanged
+                continue;
+            }
+
+            // Outside the cursor shape: apply white glow if there is any
+            if (glow > 0.0f) {
+                uint8_t glowAlpha = (uint8_t)(glow * 255.0f + 0.5f); // round to nearest
+                pixels[i * 4 + 0] = glowAlpha; // A
+                pixels[i * 4 + 1] = glowAlpha; // R (premultiplied white)
+                pixels[i * 4 + 2] = glowAlpha; // G (premultiplied white)
+                pixels[i * 4 + 3] = glowAlpha; // B (premultiplied white)
+            }
+        }
+
+        // --- Step 6: Create output CGImage ---
+        CGImageRef outputImage = CGBitmapContextCreateImage(context);
+
+        // --- Step 7: Clean up ---
+        free(alpha);
+        free(temp);
+        free(blurred);
+        CGContextRelease(context);
+
+        if (!outputImage) {
+            MMLog("MCApplyOuterGlow: failed to create output image");
+            return NULL;
+        }
+
+        return outputImage;
+    } // @autoreleasepool
+}

--- a/Mousecape/mousecloak/restore.m
+++ b/Mousecape/mousecloak/restore.m
@@ -33,7 +33,7 @@ void restoreCursorForIdentifier(NSString *ident) {
           cape ? "YES" : "NO");
 
     if (cape && registered) {
-        BOOL success = applyCapeForIdentifier(cape, restoreIdent, YES);
+        BOOL success = applyCapeForIdentifier(cape, restoreIdent, YES, NO);
         MMLog("    Restore result: %s", success ? "SUCCESS" : "FAILED");
     } else {
         MMLog("    Skipped - no cape or not registered");

--- a/Mousecape/mousecloak/scale.h
+++ b/Mousecape/mousecloak/scale.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 extern float cursorScale(void);
 extern float defaultCursorScale(void);
 extern BOOL setCursorScale(float scale);
+extern BOOL customScaleMode(void);
+extern void setCustomScaleMode(BOOL isCustom);
 
 NS_ASSUME_NONNULL_END
 

--- a/Mousecape/mousecloak/scale.m
+++ b/Mousecape/mousecloak/scale.m
@@ -12,6 +12,9 @@
 #import "CGSCursor.h"
 #import <math.h>
 
+// Direct in-process flag — bypasses CFPreferences caching issues
+static BOOL g_customScaleMode = NO;
+
 float cursorScale(void) {
     float value;
     CGSGetCursorScale(CGSMainConnectionID(), &value);
@@ -36,4 +39,13 @@ BOOL setCursorScale(float dbl) {
         MMLog("Somehow failed to set cursor scale!");
         return NO;
     }
+}
+
+BOOL customScaleMode(void) {
+    return g_customScaleMode;
+}
+
+void setCustomScaleMode(BOOL isCustom) {
+    g_customScaleMode = isCustom;
+    MMLog("Scale mode set to: %s", isCustom ? "custom" : "global");
 }

--- a/Mousecape/mousecloak/scale.m
+++ b/Mousecape/mousecloak/scale.m
@@ -12,8 +12,10 @@
 #import "CGSCursor.h"
 #import <math.h>
 
-// Direct in-process flag — bypasses CFPreferences caching issues
+// Process-local cache of scale mode — initialized lazily from CFPreferences
+// on first access to avoid stale defaults across multiple processes.
 static BOOL g_customScaleMode = NO;
+static BOOL g_scaleModeInitialized = NO;
 
 float cursorScale(void) {
     float value;
@@ -42,10 +44,38 @@ BOOL setCursorScale(float dbl) {
 }
 
 BOOL customScaleMode(void) {
+    if (!g_scaleModeInitialized) {
+        g_scaleModeInitialized = YES;
+        NSString *mode = (__bridge_transfer NSString *)CFPreferencesCopyValue(
+            CFSTR("MCScaleMode"),
+            CFSTR("com.sdmj76.Mousecape"),
+            kCFPreferencesCurrentUser,
+            kCFPreferencesCurrentHost
+        );
+        g_customScaleMode = [mode isEqualToString:@"custom"];
+        MMLog("Scale mode initialized from preferences: %s", g_customScaleMode ? "custom" : "global");
+    }
     return g_customScaleMode;
 }
 
 void setCustomScaleMode(BOOL isCustom) {
     g_customScaleMode = isCustom;
+    g_scaleModeInitialized = YES;
+
+    // Persist to CFPreferences so other processes (Helper) pick up the change
+    NSString *modeValue = isCustom ? @"custom" : @"global";
+    CFPreferencesSetValue(
+        CFSTR("MCScaleMode"),
+        (__bridge CFPropertyListRef)modeValue,
+        CFSTR("com.sdmj76.Mousecape"),
+        kCFPreferencesCurrentUser,
+        kCFPreferencesCurrentHost
+    );
+    CFPreferencesSynchronize(
+        CFSTR("com.sdmj76.Mousecape"),
+        kCFPreferencesCurrentUser,
+        kCFPreferencesCurrentHost
+    );
+
     MMLog("Scale mode set to: %s", isCustom ? "custom" : "global");
 }


### PR DESCRIPTION
## Summary
- **Cursor Scale System** — Two-mode scaling: Global (single slider for all cursors) or Custom (per-cursor-type individual scaling)
- **High-resolution support** — Extended scale range up to 16x with 2048px standard cursor size for sharp rendering on high-DPI displays
- **Cursor effects** — Added inner shadow and outer glow effects using Accelerate vImage framework
- **Apply result feedback** — Detailed reporting after applying a cape, showing success/failure/skipped counts and per-cursor error details
- **Cursor image skip** — Cursors with no image data are now skipped rather than failing silently during apply
- **Hotspot accuracy** — Hotspot now scales proportionally when per-cursor scaling is applied, maintaining correct cursor position
- **Scale persistence** — Global scale mode now persists correctly across app restarts via separate MCGlobalCursorScale preference

## Test plan
- [ ] Build the app in Xcode and apply a cape — verify it applies without errors
- [ ] Test Global vs Custom scale mode switching
- [ ] Test left-hand mode with scale enabled
- [ ] Verify session monitor restores correct scale after wake/reconnect
- [ ] Verify detailed apply result alert shows correct counts when some cursors fail